### PR TITLE
fix modnotify-32-rmb.  Use rmb 19.1.2, that has no problems with bad queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>19.1.0</version>
+      <version>19.1.2</version>
     </dependency>
 
     <dependency>

--- a/src/test/java/org/folio/rest/impl/NotifyTest.java
+++ b/src/test/java/org/folio/rest/impl/NotifyTest.java
@@ -299,17 +299,17 @@ public class NotifyTest {
       .header(TEN)
       .get("/notify?query=BADQUERY")
       .then().log().ifValidationFails()
-      .statusCode(400);
+      .statusCode(422);
     given()
       .header(TEN)
       .get("/notify?query=BADFIELD=foo")
       .then().log().ifValidationFails()
-      .statusCode(400);
+      .statusCode(422);
     given()
       .header(TEN)
       .get("/notify?query=metadata.BADFIELD=foo")
       .then().log().ifValidationFails()
-      .statusCode(400);
+      .statusCode(422);
 
     // Update a notification
     String updated1 = "{"


### PR DESCRIPTION
Fix some test cases too, bad queries now return 422 as they should