### PR TITLE
Upgrade to RMB 23.1.0 MODNOTIFY-47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
-    <raml-module-builder.version>21.0.1</raml-module-builder.version>
+    <raml-module-builder.version>23.1.0</raml-module-builder.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <vertx-version>3.5.4</vertx-version>
   </properties>
@@ -116,7 +116,12 @@
         </exclusion>
       </exclusions>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.4.6</version>
+      <type>jar</type>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
For some reason we need extra import of org.apache.httpcomponents
- apparently no longer indirectly provided by RMB