### PR TITLE
MODTEMPENG-13 Changing 'template-engine' required version

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -12,7 +12,7 @@
     },
     {
       "id": "template-engine",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "message-delivery",


### PR DESCRIPTION
## Purpose
Resolves: MODTEMPENG-13
Change 'template-engine' required version
Has to be merged together with: https://github.com/folio-org/mod-template-engine/pull/19
## Links
https://issues.folio.org/browse/MODTEMPENG-13