### PR TITLE
Update to use RMB25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
-    <raml-module-builder.version>24.0.0</raml-module-builder.version>
+    <raml-module-builder.version>25.0.1</raml-module-builder.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <vertx-version>3.5.4</vertx-version>
   </properties>

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -2,8 +2,6 @@
   "tables": [
     {
       "tableName": "notify_data",
-      "generateId": true,
-      "populateJsonWithId": true,
       "withMetadata": true,
       "ginIndex": [
         {

--- a/src/test/java/org/folio/rest/impl/NotifyTest.java
+++ b/src/test/java/org/folio/rest/impl/NotifyTest.java
@@ -425,7 +425,7 @@ public class NotifyTest {
 
     given() // get it via the link.
       .header(TEN).header(USER7)
-      .get("/notify?query=link=*34567*")
+      .get("/notify?query=link=\"things/34567\"")
       .then().log().all() // ifValidationFails()
       .statusCode(200)
       .body(containsString("id")) // auto-generated id field

--- a/src/test/java/org/folio/rest/impl/NotifyTest.java
+++ b/src/test/java/org/folio/rest/impl/NotifyTest.java
@@ -425,7 +425,7 @@ public class NotifyTest {
 
     given() // get it via the link.
       .header(TEN).header(USER7)
-      .get("/notify?query=link=\"things/34567\"")
+      .get("/notify?query=link=\"things/34567*\"")
       .then().log().all() // ifValidationFails()
       .statusCode(200)
       .body(containsString("id")) // auto-generated id field


### PR DESCRIPTION
Update RMB dependency from `24.0.0` to `25.0.1`. Most changes are straightforward. One noteworthy thing is that I have to adjust one test to get it pass. The reason is the default PG full text `simple` dictionary does not split words by `/`.
```
data: "link": "things/34567"
query syntax before: query=link=*34567*
query syntax after: query=link="things/34567*"
CQL >>> SQL: link="things/34567*" >>> WHERE to_tsvector('simple', f_unaccent(notify_data.jsonb->>'link')) @@ to_tsquery('simple', f_unaccent('things/34567:*')) LIMIT 10 OFFSET 0
```