### PR TITLE
[MODNOTIFY-60] Provide ability to handle attachments

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -22,7 +22,7 @@
   "provides": [
     {
       "id": "notify",
-      "version": "2.0",
+      "version": "2.1",
       "handlers": [
         {
           "methods": ["GET"],
@@ -63,7 +63,7 @@
     },
     {
       "id": "patron-notice",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": ["POST"],

--- a/ramls/attachment.json
+++ b/ramls/attachment.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Message attachment",
+  "additionalProperties": false,
+  "properties": {
+    "contentType": {
+      "type": "string",
+      "description": "Content type"
+    },
+    "name": {
+      "type": "string",
+      "description": "Name"
+    },
+    "description": {
+      "type": "string",
+      "description": "Description"
+    },
+    "data": {
+      "type": "string",
+      "description": "Attachment data"
+    },
+    "disposition": {
+      "type": "string",
+      "description": "Disposition"
+    },
+    "contentId": {
+      "type": "string",
+      "description": "Content id"
+    }
+  }
+}

--- a/ramls/message.json
+++ b/ramls/message.json
@@ -27,6 +27,15 @@
     "outputFormat": {
       "type": "string",
       "description": "Media type of message body"
+    },
+    "attachments": {
+      "description": "List of attachments",
+      "id": "attachments",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "attachment.json"
+      }
     }
   },
   "required": [

--- a/ramls/notify.raml
+++ b/ramls/notify.raml
@@ -2,7 +2,7 @@
 
 title: Notifications API
 baseUri: https://github.com/folio-org/mod-notify
-version: v1
+version: v2.1
 
 documentation:
   - title: mod-notify API

--- a/ramls/patron-notice.raml
+++ b/ramls/patron-notice.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 title: Patron Notice API
 baseUri: https://github.com/folio-org/mod-notify
-version: v1
+version: v1.1
 
 documentation:
   - title: mod-notify API

--- a/ramls/templateContent.json
+++ b/ramls/templateContent.json
@@ -11,6 +11,15 @@
     "body": {
       "type": "string",
       "description": "Template for body"
+    },
+    "attachments": {
+      "description": "List of attachments",
+      "id": "attachments",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "attachment.json"
+      }
     }
   }
 }

--- a/src/main/java/org/folio/helper/OkapiModulesClientHelper.java
+++ b/src/main/java/org/folio/helper/OkapiModulesClientHelper.java
@@ -22,10 +22,11 @@ public class OkapiModulesClientHelper {
   public static NotifySendRequest buildNotifySendRequest(TemplateProcessingResult result, PatronNoticeEntity entity) {
 
     Message message = new Message()
-      .withHeader(result.getResult().getHeader())
-      .withBody(result.getResult().getBody())
-      .withDeliveryChannel(entity.getDeliveryChannel())
-      .withOutputFormat(entity.getOutputFormat());
+        .withHeader(result.getResult().getHeader())
+        .withBody(result.getResult().getBody())
+        .withAttachments(result.getResult().getAttachments())
+        .withDeliveryChannel(entity.getDeliveryChannel())
+        .withOutputFormat(entity.getOutputFormat());
 
     return new NotifySendRequest()
       .withNotificationId(UUID.randomUUID().toString())

--- a/src/test/java/org/folio/rest/impl/PatronNoticeTest.java
+++ b/src/test/java/org/folio/rest/impl/PatronNoticeTest.java
@@ -12,6 +12,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.folio.rest.RestVerticle;
+import org.folio.rest.jaxrs.model.Attachment;
 import org.folio.rest.jaxrs.model.PatronNoticeEntity;
 import org.folio.rest.jaxrs.model.Result;
 import org.folio.rest.jaxrs.model.TemplateProcessingResult;
@@ -24,6 +25,9 @@ import org.junit.runner.RunWith;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+
+import java.util.Collections;
+import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
@@ -141,7 +145,8 @@ public class PatronNoticeTest {
       .withTemplateId(TEMPLATE_ID)
       .withResult(new Result()
         .withHeader("header")
-        .withBody("body"));
+        .withBody("body")
+        .withAttachments(buildAttachments()));
 
     mockServer.stubFor(post(urlMatching("/template-request"))
       .withRequestBody(matchingJsonPath(TEMPLATE_ID_JSON_PATH, equalTo(TEMPLATE_ID)))
@@ -158,5 +163,15 @@ public class PatronNoticeTest {
     mockServer.stubFor(post(urlMatching("/message-delivery"))
       .withRequestBody(matchingJsonPath(RECIPIENT_ID_JSON_PATH, equalTo(INCORRECT_RECIPIENT_ID)))
       .willReturn(ok().withStatus(400)));
+  }
+
+  private static List<Attachment> buildAttachments() {
+    Attachment attachment = new Attachment()
+        .withData("ABCDEFG")
+        .withContentType("image/png")
+        .withDisposition("inline")
+        .withName("test")
+        .withContentId("<test>");
+    return Collections.singletonList(attachment);
   }
 }


### PR DESCRIPTION
**Purpose**
Provide the ability to pass attachments from `mod-template-engine` to `mod-sender`.

**Links**
[MODNOTIFY-60](https://issues.folio.org/browse/MODNOTIFY-60)
[MODTEMPENG-34](https://issues.folio.org/browse/MODTEMPENG-34) (original story)