### PR TITLE
MODNOTIFY-81: Replace CQL = by ==, fix CQL injection, use url encoding

### DIFF
--- a/src/test/resources/mock_content.json
+++ b/src/test/resources/mock_content.json
@@ -2,7 +2,7 @@
   "mocks": [
     {
       "description": "Simple user for looking up",
-      "url": "/users?query=username=mockuser9",
+      "url": "/users?query=username%3D%3D%22mockuser9%22",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -43,7 +43,7 @@
     },
     {
       "description": "User lookup that succeeds, but lacks critical data",
-      "url": "/users?query=username=badmockuser",
+      "url": "/users?query=username%3D%3D%22badmockuser%22",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -79,7 +79,7 @@
     },
     {
       "description": "User not found",
-      "url": "/users?query=username=notfound",
+      "url": "/users?query=username%3D%3D%22notfound%22",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -89,13 +89,13 @@
     },
     {
       "description": "Error in lookup",
-      "url": "/users?query=username=error",
+      "url": "/users?query=username%3D%3D%22error%22",
       "method": "get",
       "status": 500
     },
     {
       "description": "Permission problem",
-      "url": "/users?query=username=permissionproblem",
+      "url": "/users?query=username%3D%3D%22permissionproblem%22",
       "method": "get",
       "status": 403
     }


### PR DESCRIPTION
The username query uses
/users?query=username=foo
There is no masking of special CQL characters: * ? \ "
The CQL string constant should be quoted.
For example `foo*bar` is `"foo\*bar"`.
The = CQL operator is a word match. The == full field CQL operator is needed.
Correct CQL: username=="foo"
Correct URL after url encoding: /users?query=username%3D%3D%22foo%22

References:
* https://dev.folio.org/faqs/explain-cql/
* https://github.com/folio-org/raml-module-builder#cql-relations
* https://www.loc.gov/standards/sru/cql/spec.html
* https://www.loc.gov/standards/sru/cql/contextSets/theCqlContextSet.html