### PR TITLE
MODNOTIFY-99 Update RMB to v33.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,9 @@
   <properties>
     <argLine />
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <raml-module-builder.version>33.2.2</raml-module-builder.version>
+    <raml-module-builder.version>33.2.4</raml-module-builder.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <vertx-version>4.2.1</vertx-version>
+    <vertx-version>4.2.4</vertx-version>
   </properties>
 
   <repositories>
@@ -146,7 +146,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.10.0</version>
+      <version>4.2.0</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
### Purpose
In the scope of the task on module upgrade, proper actions were fulfilled following instructions to update RMB
### Approach
•	Updated RMB version
•	Updated Vertx version
•	Updated mockito-core
### Learning
https://issues.folio.org/browse/MODNOTIFY-99
https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md
