### PR TITLE
MODNOTIFY-124 Fixed Null Pointer Exception

### DIFF
--- a/src/main/java/org/folio/client/NoticesClient.java
+++ b/src/main/java/org/folio/client/NoticesClient.java
@@ -64,12 +64,12 @@ public class NoticesClient extends OkapiClient {
   }
 
   public Future<Void> postMessageDelivery(NotifySendRequest request) {
-    log.debug("postMessageDelivery:: parameters request: {}", () -> asJson(request));
+    log.info("postMessageDelivery:: parameters request: {}", () -> asJson(request));
     Promise<HttpResponse<Buffer>> promise = Promise.promise();
     postAbs("/message-delivery")
       .putHeader(ACCEPT, TEXT_PLAIN)
       .sendJson(request, promise);
-
+    log.info("postMessageDelivery:: promise {}", promise);
     return promise.future()
       .onSuccess(r -> log.info("postMessageDelivery:: result: {}", () -> bodyAsString(r)))
       .map(responseMapper(Void.class));

--- a/src/main/java/org/folio/client/NoticesClient.java
+++ b/src/main/java/org/folio/client/NoticesClient.java
@@ -64,12 +64,12 @@ public class NoticesClient extends OkapiClient {
   }
 
   public Future<Void> postMessageDelivery(NotifySendRequest request) {
-    log.info("postMessageDelivery:: parameters request: {}", () -> asJson(request));
+    log.debug("postMessageDelivery:: parameters request: {}", () -> asJson(request));
     Promise<HttpResponse<Buffer>> promise = Promise.promise();
     postAbs("/message-delivery")
       .putHeader(ACCEPT, TEXT_PLAIN)
       .sendJson(request, promise);
-    log.info("postMessageDelivery:: promise {}", promise);
+
     return promise.future()
       .onSuccess(r -> log.info("postMessageDelivery:: result: {}", () -> bodyAsString(r)))
       .map(responseMapper(Void.class));

--- a/src/main/java/org/folio/util/LogUtil.java
+++ b/src/main/java/org/folio/util/LogUtil.java
@@ -108,8 +108,9 @@ public class LogUtil {
   }
 
   public static String bodyAsString(HttpResponse<Buffer> response) {
-    log.info("bodyAsString:: json Object {}", response.bodyAsJsonObject());
-    log.info("bodyAsString:: response {}", response.bodyAsString());
+    log.info("bodyAsString:: response Object {}", response);
+    log.info("bodyAsString:: buffer Object {}", response.bodyAsBuffer());
+    log.info("bodyAsString:: response bodyAsString {}", response.bodyAsString());
     try {
       return crop(response.bodyAsString().replaceAll(R_N_LINE_SEPARATOR, R_LINE_SEPARATOR));
     } catch (Exception ex) {

--- a/src/main/java/org/folio/util/LogUtil.java
+++ b/src/main/java/org/folio/util/LogUtil.java
@@ -108,7 +108,7 @@ public class LogUtil {
   }
 
   public static String bodyAsString(HttpResponse<Buffer> response) {
-    log.info("bodyAsString:: response {}", response);
+    log.info("bodyAsString:: json Object {}", response.bodyAsJsonObject());
     log.info("bodyAsString:: response {}", response.bodyAsString());
     try {
       return crop(response.bodyAsString().replaceAll(R_N_LINE_SEPARATOR, R_LINE_SEPARATOR));

--- a/src/main/java/org/folio/util/LogUtil.java
+++ b/src/main/java/org/folio/util/LogUtil.java
@@ -5,6 +5,7 @@ import static java.lang.String.format;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.core.Response;
@@ -108,13 +109,11 @@ public class LogUtil {
   }
 
   public static String bodyAsString(HttpResponse<Buffer> response) {
-    log.info("bodyAsString:: response body {}", response.body());
-    log.info("bodyAsString:: response toString {}", response.toString());
-    log.info("bodyAsString:: response statuscode {}", response.statusCode());
-    log.info("bodyAsString:: buffer Object {}", response.bodyAsBuffer());
-    log.info("bodyAsString:: response bodyAsString {}", response.bodyAsString());
     try {
-      return crop(response.bodyAsString().replaceAll(R_N_LINE_SEPARATOR, R_LINE_SEPARATOR));
+      return Optional.ofNullable(response.bodyAsString())
+        .map(LogUtil::crop)
+        .map(str -> str.replaceAll(R_N_LINE_SEPARATOR, R_LINE_SEPARATOR))
+        .orElse(null);
     } catch (Exception ex) {
       log.warn("logResponseBody:: Failed to log an HTTP response", ex);
       return null;

--- a/src/main/java/org/folio/util/LogUtil.java
+++ b/src/main/java/org/folio/util/LogUtil.java
@@ -109,15 +109,13 @@ public class LogUtil {
 
   public static String bodyAsString(HttpResponse<Buffer> response) {
     log.info("bodyAsString:: response {}", response);
-    if(response !=null){
-      try {
-        return crop(response.bodyAsString().replaceAll(R_N_LINE_SEPARATOR, R_LINE_SEPARATOR));
-      } catch (Exception ex) {
-        log.warn("logResponseBody:: Failed to log an HTTP response", ex);
-        return null;
-      }
+    log.info("bodyAsString:: response {}", response.bodyAsString());
+    try {
+      return crop(response.bodyAsString().replaceAll(R_N_LINE_SEPARATOR, R_LINE_SEPARATOR));
+    } catch (Exception ex) {
+      log.warn("logResponseBody:: Failed to log an HTTP response", ex);
+      return null;
     }
-    return null;
   }
 
   public static Handler<AsyncResult<Response>> loggingResponseHandler(String methodName,

--- a/src/main/java/org/folio/util/LogUtil.java
+++ b/src/main/java/org/folio/util/LogUtil.java
@@ -108,7 +108,9 @@ public class LogUtil {
   }
 
   public static String bodyAsString(HttpResponse<Buffer> response) {
-    log.info("bodyAsString:: response Object {}", response);
+    log.info("bodyAsString:: response body {}", response.body());
+    log.info("bodyAsString:: response toString {}", response.toString());
+    log.info("bodyAsString:: response statuscode {}", response.statusCode());
     log.info("bodyAsString:: buffer Object {}", response.bodyAsBuffer());
     log.info("bodyAsString:: response bodyAsString {}", response.bodyAsString());
     try {

--- a/src/main/java/org/folio/util/LogUtil.java
+++ b/src/main/java/org/folio/util/LogUtil.java
@@ -108,12 +108,16 @@ public class LogUtil {
   }
 
   public static String bodyAsString(HttpResponse<Buffer> response) {
-    try {
-      return crop(response.bodyAsString().replaceAll(R_N_LINE_SEPARATOR, R_LINE_SEPARATOR));
-    } catch (Exception ex) {
-      log.warn("logResponseBody:: Failed to log an HTTP response", ex);
-      return null;
+    log.info("bodyAsString:: response {}", response);
+    if(response !=null){
+      try {
+        return crop(response.bodyAsString().replaceAll(R_N_LINE_SEPARATOR, R_LINE_SEPARATOR));
+      } catch (Exception ex) {
+        log.warn("logResponseBody:: Failed to log an HTTP response", ex);
+        return null;
+      }
     }
+    return null;
   }
 
   public static Handler<AsyncResult<Response>> loggingResponseHandler(String methodName,


### PR DESCRIPTION
## Purpose
MODNOTIFY-124 - https://issues.folio.org/browse/MODNOTIFY-124
The purpose of the PR is to fix null pointer exception which occurs in the logs.

## Approach
The Null pointer exception occurs at the time converting Http Response body to string. Now wrapped this inside the optional and handle it accordingly.

**Evidences:** 

[mod-notify-before-fix.log](https://github.com/folio-org/mod-notify/files/11322422/mod-notify-before-fix.log)
[mod-notify-after-fix.log](https://github.com/folio-org/mod-notify/files/11322423/mod-notify-after-fix.log)

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
