### PR TITLE
MODNOTIFY-131: maven-model 3.9.5, plexus-utils 3.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,8 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>3.3.9</version>
+      <version>3.9.5</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>


### PR DESCRIPTION
https://issues.folio.org/browse/MODNOTIFY-131

Upgrade maven-model from 3.3.9 to 3.9.5, and move it to test dependency.

The upgrade indirectly upgrades plexus-utils from 3.0.22 to 3.5.1 fixing Directory Traversal and XML External Entity (XXE) Injection:
https://nvd.nist.gov/vuln/detail/CVE-2022-4244
https://nvd.nist.gov/vuln/detail/CVE-2022-4245

Because maven-model/plexus-utils is used in test code only this doesn't affect production code and no bug fix release is needed for this issue.